### PR TITLE
Fix right click menu entry in disassembly view

### DIFF
--- a/win_driver_plugin.py
+++ b/win_driver_plugin.py
@@ -124,8 +124,8 @@ def find_all_ioctls():
     fc = idaapi.FlowChart(f, flags=idaapi.FC_PREDS)
     for block in fc:
         # grab the last two instructions in the block 
-        last_inst = idc.PrevHead(block.end_ea)
-        penultimate_inst = idc.PrevHead(last_inst)
+        last_inst = idc.prev_head(block.end_ea)
+        penultimate_inst = idc.prev_head(last_inst)
         # If the penultimate instruction is cmp or sub against an immediate value immediately preceding a 'jz' 
         # then it's a decent guess that it's an IOCTL code (if this is a dispatch function)
         if idc.print_insn_mnem(penultimate_inst) in ['cmp', 'sub'] and idc.get_operand_type(penultimate_inst, 1) == 5:

--- a/win_driver_plugin.py
+++ b/win_driver_plugin.py
@@ -335,9 +335,8 @@ def register_dynamic_action(form, popup, description, handler):
 class WinDriverHooks(idaapi.UI_Hooks):
     """Installs hook function which is triggered when popup forms are created and adds extra menu options if it is the right-click disasm view menu"""
 
-    def finish_populating_tform_popup(self, form, popup):
-        tft = idaapi.get_tform_type(form)
-        if tft != idaapi.BWN_DISASM:
+    def finish_populating_widget_popup(self, form, popup):
+        if idaapi.get_widget_type(form) != idaapi.BWN_DISASM:
             return
 
         pos = idc.get_screen_ea()


### PR DESCRIPTION
Hi,

We are creating a long chain of PRs here that seem to be having a hard time finding their way upstream :)

[FSecureLABS/win_driver_plugin](https://github.com/FSecureLABS/win_driver_plugin) (original repository)
^
[alexander-pick/win_driver_plugin](https://github.com/alexander-pick/win_driver_plugin) (added IDA 7 support)
^
[sisoma2/win_driver_plugin](https://github.com/sisoma2/win_driver_plugin) (you - added Python 3 support)
^
[Mattiwatti/win_driver_plugin](https://github.com/Mattiwatti/win_driver_plugin) (mine - this PR)

Since you were the last person to touch this code as far as I can tell, you get the honours of receiving my PR. Do with it whatever you want.

This fixes some cases of outdated API usage that were causing the right click menu entry in the disassembly view not to work.
> **WARNING:** The method "ida_kernwin.UI_Hooks::finish_populating_tform_popup" won't be called (it has been replaced with "ida_kernwin.UI_Hooks::finish_populating_widget_popup")

Fixing this leads to the next problem, this time a call to a function that no longer exists:
> Exception in ida_kernwin.UI_Hooks dispatcher function: SWIG director method error. Error detected when calling 'UI_Hooks.finish_populating_widget_popup'
> Traceback (most recent call last):
> File "C:/Program Files/IDA 7.4/plugins/win_driver_plugin.py", line 339, in finish_populating_widget_popup
> tft = idaapi.get_tform_type(form)
>AttributeError: 'module' object has no attribute 'get_tform_type'

With the first commit the menu entry is once again added to the right click menu in the disassembly view. However, the 'find all IOCTLs in function' menu command will now fail:
> Traceback (most recent call last):
>  File "C:/Program Files/IDA 7.4/plugins/win_driver_plugin.py", line 290, in activate
>    decode_all_ioctls()
>  File "C:/Program Files/IDA 7.4/plugins/win_driver_plugin.py", line 150, in decode_all_ioctls
>    ioctls = find_all_ioctls()
>  File "C:/Program Files/IDA 7.4/plugins/win_driver_plugin.py", line 127, in find_all_ioctls
>    last_inst = idc.PrevHead(block.end_ea)
>AttributeError: 'module' object has no attribute 'PrevHead'

This is trivially fixed (in the second commit) by updating uses of `PrevHead` with the new `prev_head`.